### PR TITLE
Using Rerankers on InstructIR

### DIFF
--- a/eval/combine_rerank.sh
+++ b/eval/combine_rerank.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+SPLIT='test'
+CORPUS='corpus.jsonl'
+DATA='INSTRUCTIR'
+RERANK_FROM=bm25
+
+echo "SPLIT = $SPLIT"
+echo "CORPUS = $CORPUS"
+echo "DATA = $DATA"
+echo "RERANK_FROM = $RERANK_FROM"
+
+########################################################
+###### - version : Normal inference mode
+########################################################
+/home/oweller2/anaconda3/envs/kaist-instructir/bin/python -u eval_instructir_bm25_rerank_combine_and_score.py \
+    --data_path $DATA \
+    --corpus_file $CORPUS \
+    --split $SPLIT \
+    --model_name $1 \
+    --n_shards $2 \
+    --rerank_model $RERANK_FROM

--- a/eval/eval_instructir_bm25.py
+++ b/eval/eval_instructir_bm25.py
@@ -65,6 +65,12 @@ def main(args):
     #### Retrieve pyserini results (format of results is identical to qrels)
     results = json.loads(requests.post(docker_beir_pyserini + "/lexical/batch_search/", json=payload).text)["results"]
 
+    # save the results
+    if not os.path.exists('model_pred/bm25'):
+        os.makedirs('model_pred/bm25')
+    with open('model_pred/bm25/results.pickle','wb') as f:
+        pickle.dump(results,f)
+
     logging.info(f"searched results: {len(results)}")
     #### Retrieve RM3 expanded pyserini results (format of results is identical to qrels)
     # results = json.loads(requests.post(docker_beir_pyserini + "/lexical/rm3/batch_search/", json=payload).text)["results"]

--- a/eval/eval_instructir_bm25_rerank.py
+++ b/eval/eval_instructir_bm25_rerank.py
@@ -47,84 +47,58 @@ def main(args):
                 fOut.write('\n')
 
     logging.info("File converted")
-    #### Download Docker Image beir/pyserini-fastapi ####
-    #### Locally run the docker Image + FastAPI ####
-    docker_beir_pyserini = "http://localhost:8000"
+ 
+    with open(f"model_pred/{args.rerank_model}/results.pickle", "rb") as f:
+        results = pickle.load(f)
 
-    # #### Upload Multipart-encoded files ####
-    # with open(os.path.join(args.data_path, pyserini_jsonl), "rb") as fIn:
-    #     r = requests.post(docker_beir_pyserini + "/upload/", files={"file": fIn}, verify=False)
-
-    # logging.info("Upload Multipart-encoded files")
-    # #### Index documents to Pyserini #####
-    # index_name='target'
-    # r = requests.get(docker_beir_pyserini + "/index/", params={"index_name": index_name})
-
-    #### Retrieve documents from Pyserini #####
-    # retriever = EvaluateRetrieval()
-    retriever = CustomEvaluateRetrieval()
-
-    qids = list(queries.keys())
-    query_texts = [queries[qid] for qid in qids]
-    payload = {"queries": query_texts, "qids": qids, "k": max(retriever.k_values)}
-
-    #### Retrieve pyserini results (format of results is identical to qrels)
-    results = json.loads(requests.post(docker_beir_pyserini + "/lexical/batch_search/", json=payload).text)["results"]
     # dict of {query_id: {doc_id: score, doc_id: score, ...}, query_id: ...}
-    logging.info(f"searched results: {len(results)}")
+    logging.info(f"loaded results: {len(results)}")
+
+    # sort the query ids and then shard in args.n_shards pieces, keeping args.shard_id
+    query_ids = sorted(list(queries.keys()))
+    query_ids = query_ids[args.shard_id::args.n_shards]
+    print(f"Shard {args.shard_id} has {len(query_ids)} queries: {query_ids}")
+    results = {query_id: results[query_id] for query_id in query_ids}
 
     #### Rerank the results ####
-    reranked_results = defaultdict(dict)
-    for query in tqdm.tqdm(results.keys()):
-        # gather all the top 1000 docs
-        docs_w_scores = [(doc, score) for doc, score in results[query].items()]
+
+    # batch them first to avoid lag in processing
+    batches = []
+    for query_id in tqdm.tqdm(results.keys()):
+        # gather all the top n docs
+        docs_w_scores = [(doc, score) for doc, score in results[query_id].items()]
         docs_w_scores.sort(key=lambda x: x[1], reverse=True)
-        # take the top 1000 scores from those docs
-        docs = [doc for doc, score in docs_w_scores[:1000]]
+        # take the top n scores from those docs
+        docs = [doc for doc, score in docs_w_scores[:args.rerank_n]]
         # grab the document text
         doc_texts = [corpus[doc]['text'] for doc in docs]
+        assert len(doc_texts) <= args.rerank_n, f"len(doc_texts)={len(doc_texts)}"
         # grab the query text
-        query_text = queries[query]
+        query_text = queries[query_id]
         query = query_text.split(" [SEP] ")[-1]
         instruction = query_text.split(" [SEP] ")[0]
-        # batch over the doc_texts for args.batch_size
-        reranked_results = []
+        batches.append((query, doc_texts, instruction, query_id, docs))
+
+    assert len(batches), "No batches to rerank"
+    print(f"Reranking {len(batches)} batches")
+
+    # rerank the batches
+    reranked_results_batched = defaultdict(dict)
+    for query, doc_texts, instruction, query_id, docs in tqdm.tqdm(batches):
         for i in tqdm.tqdm(range(0, len(doc_texts), args.batch_size), leave=False):
             batch_docs = doc_texts[i:i+args.batch_size]
             reranked = reranker_model.rerank([query] * len(batch_docs), batch_docs, instructions=[instruction] * len(batch_docs))
-            reranked_results.extend(reranked)
-       
-        # turn into a dictionary
-        reranked = {doc: score for doc, score in zip(docs, reranked_results)}
-        reranked_results[query] = reranked
+            reranked_results_batched[query_id].update({doc: score for doc, score in zip(docs[i:i+args.batch_size], reranked)})
+            # print(f"Example reranked: {reranked}")
 
-    results = reranked_results
+    results = reranked_results_batched
 
-    #### Retrieve RM3 expanded pyserini results (format of results is identical to qrels)
-    # results = json.loads(requests.post(docker_beir_pyserini + "/lexical/rm3/batch_search/", json=payload).text)["results"]
+    # save them to file
+    model_name = args.model_name.replace("/", "-")
+    os.makedirs(f"model_pred/{model_name}", exist_ok=True)
+    with open(f"model_pred/{model_name}/{args.shard_id}_{args.n_shards}.pickle", "wb") as f:
+        pickle.dump(results, f)
 
-    #### Check if query_id is in results i.e. remove it from docs incase if it appears ####
-    #### Quite Important for ArguAna and Quora ####
-    for query_id in reranked_results:
-        if query_id in reranked_results[query_id]:
-            reranked_results[query_id].pop(query_id, None)
-
-    logging.info("Retriever evaluation for k in: {}".format(retriever.k_values))
-    # metrics = retriever.evaluate(qrels, results, retriever.k_values)
-    # metrics = retriever.robustness_evaluate(queries, qrels, results, retriever.k_values,type='instruction')
-    metrics = retriever.robustness_evaluate(queries, qrels, reranked_results, retriever.k_values,type='query')
-    print(metrics)
-    ##### Save
-    # data_path = args.data_path.split('/')[-2]
-    # corpus_file = args.corpus_file.split('.')[0]
-    # split_flag = args.split
-    # query_version = args.query_file.split('.')[0].replace('/','_')
-    # save_path = f'model_pred/{data_path}/{corpus_file}/{split_flag}/{query_version}/'
-
-    # os.makedirs(save_path, exist_ok=True)
-    # save_path += 'bm25.pickle'
-    # with open(save_path,'wb') as f:
-    #     pickle.dump(results,f)
         
 if __name__=="__main__":    
     parser = argparse.ArgumentParser(
@@ -140,8 +114,12 @@ if __name__=="__main__":
     parser.add_argument("--qrels_folder", type=str, default='qrels',
                         help="qrels folder name")
     parser.add_argument("--model_name", type=str, default='jhu-clsp/FollowIR-7B')
-    parser.add_argument("--batch_size", type=int, default=32)
+    parser.add_argument("--rerank_n", type=int, default=100)
+    parser.add_argument("--batch_size", type=int, default=64)
+    parser.add_argument("--n_shards", type=int, default=1)
+    parser.add_argument("--shard_id", type=int, default=0)
     parser.add_argument("--change_instruction_order", action="store_true", help="change the order of instructions and query")
+    parser.add_argument("--rerank_model", type=str, default='bm25')
     cfg, _ = parser.parse_known_args()
-
+    print(cfg)
     main(cfg)

--- a/eval/eval_instructir_bm25_rerank.py
+++ b/eval/eval_instructir_bm25_rerank.py
@@ -1,0 +1,147 @@
+'''
+Reformulate scripts from https://github.com/beir-cellar/beir/blob/main/examples/retrieval/evaluation/lexical/evaluate_anserini_bm25.py 
+'''
+import os, json
+import tqdm
+import logging
+import requests
+import argparse 
+from beir.datasets.data_loader import GenericDataLoader
+import os 
+import pickle 
+from beir import util, LoggingHandler
+from collections import defaultdict
+
+from robust_eval import CustomEvaluateRetrieval
+from src.rerankers import MODEL_DICT
+
+#### Just some code to print debug information to stdout
+logging.basicConfig(format='%(asctime)s - %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S',
+                    level=logging.INFO,
+                    handlers=[LoggingHandler()])
+
+
+def main(args):
+
+    reranker_model = MODEL_DICT[args.model_name](args.model_name)
+
+    corpus, queries, qrels = GenericDataLoader( 
+        data_folder=args.data_path,
+        corpus_file=args.corpus_file ,
+        qrels_file= os.path.join(args.data_path, args.qrels_folder,args.split + '.tsv'),
+        query_file=args.query_file,
+        ).load_custom()
+    
+    logging.info(f"len(corpus),len(queries),len(qrels): {len(corpus),len(queries),len(qrels)}")
+
+    #### Convert BEIR corpus to Pyserini Format #####
+    pyserini_jsonl = f"pyserini_{args.corpus_file.split('.')[0]}.jsonl"
+    
+    if not os.path.exists(os.path.join(args.data_path, pyserini_jsonl)):
+        with open(os.path.join(args.data_path, pyserini_jsonl), 'w', encoding="utf-8") as fOut:
+            for doc_id in corpus:
+                title, text = corpus[doc_id].get("title", ""), corpus[doc_id].get("text", "")
+                data = {"id": doc_id, "title": title, "contents": text}
+                json.dump(data, fOut)
+                fOut.write('\n')
+
+    logging.info("File converted")
+    #### Download Docker Image beir/pyserini-fastapi ####
+    #### Locally run the docker Image + FastAPI ####
+    docker_beir_pyserini = "http://localhost:8000"
+
+    # #### Upload Multipart-encoded files ####
+    # with open(os.path.join(args.data_path, pyserini_jsonl), "rb") as fIn:
+    #     r = requests.post(docker_beir_pyserini + "/upload/", files={"file": fIn}, verify=False)
+
+    # logging.info("Upload Multipart-encoded files")
+    # #### Index documents to Pyserini #####
+    # index_name='target'
+    # r = requests.get(docker_beir_pyserini + "/index/", params={"index_name": index_name})
+
+    #### Retrieve documents from Pyserini #####
+    # retriever = EvaluateRetrieval()
+    retriever = CustomEvaluateRetrieval()
+
+    qids = list(queries.keys())
+    query_texts = [queries[qid] for qid in qids]
+    payload = {"queries": query_texts, "qids": qids, "k": max(retriever.k_values)}
+
+    #### Retrieve pyserini results (format of results is identical to qrels)
+    results = json.loads(requests.post(docker_beir_pyserini + "/lexical/batch_search/", json=payload).text)["results"]
+    # dict of {query_id: {doc_id: score, doc_id: score, ...}, query_id: ...}
+    logging.info(f"searched results: {len(results)}")
+
+    #### Rerank the results ####
+    reranked_results = defaultdict(dict)
+    for query in tqdm.tqdm(results.keys()):
+        # gather all the top 1000 docs
+        docs_w_scores = [(doc, score) for doc, score in results[query].items()]
+        docs_w_scores.sort(key=lambda x: x[1], reverse=True)
+        # take the top 1000 scores from those docs
+        docs = [doc for doc, score in docs_w_scores[:1000]]
+        # grab the document text
+        doc_texts = [corpus[doc]['text'] for doc in docs]
+        # grab the query text
+        query_text = queries[query]
+        query = query_text.split(" [SEP] ")[-1]
+        instruction = query_text.split(" [SEP] ")[0]
+        # batch over the doc_texts for args.batch_size
+        reranked_results = []
+        for i in tqdm.tqdm(range(0, len(doc_texts), args.batch_size), leave=False):
+            batch_docs = doc_texts[i:i+args.batch_size]
+            reranked = reranker_model.rerank([query] * len(batch_docs), batch_docs, instructions=[instruction] * len(batch_docs))
+            reranked_results.extend(reranked)
+       
+        # turn into a dictionary
+        reranked = {doc: score for doc, score in zip(docs, reranked_results)}
+        reranked_results[query] = reranked
+
+    results = reranked_results
+
+    #### Retrieve RM3 expanded pyserini results (format of results is identical to qrels)
+    # results = json.loads(requests.post(docker_beir_pyserini + "/lexical/rm3/batch_search/", json=payload).text)["results"]
+
+    #### Check if query_id is in results i.e. remove it from docs incase if it appears ####
+    #### Quite Important for ArguAna and Quora ####
+    for query_id in reranked_results:
+        if query_id in reranked_results[query_id]:
+            reranked_results[query_id].pop(query_id, None)
+
+    logging.info("Retriever evaluation for k in: {}".format(retriever.k_values))
+    # metrics = retriever.evaluate(qrels, results, retriever.k_values)
+    # metrics = retriever.robustness_evaluate(queries, qrels, results, retriever.k_values,type='instruction')
+    metrics = retriever.robustness_evaluate(queries, qrels, reranked_results, retriever.k_values,type='query')
+    print(metrics)
+    ##### Save
+    # data_path = args.data_path.split('/')[-2]
+    # corpus_file = args.corpus_file.split('.')[0]
+    # split_flag = args.split
+    # query_version = args.query_file.split('.')[0].replace('/','_')
+    # save_path = f'model_pred/{data_path}/{corpus_file}/{split_flag}/{query_version}/'
+
+    # os.makedirs(save_path, exist_ok=True)
+    # save_path += 'bm25.pickle'
+    # with open(save_path,'wb') as f:
+    #     pickle.dump(results,f)
+        
+if __name__=="__main__":    
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--data_path", type=str, default='../data_creation/datasets/msmarco/processed_version/sample_100',
+                        help="Directory to save and load beir datasets")
+    parser.add_argument("--split", type=str,default='test',
+                        help="split for qrels")    
+    parser.add_argument("--corpus_file", type=str, default='corpus.jsonl',
+                        help="corpus file name")
+    parser.add_argument("--query_file", type=str, default='queries.jsonl',
+                        help="query file name")
+    parser.add_argument("--qrels_folder", type=str, default='qrels',
+                        help="qrels folder name")
+    parser.add_argument("--model_name", type=str, default='jhu-clsp/FollowIR-7B')
+    parser.add_argument("--batch_size", type=int, default=32)
+    parser.add_argument("--change_instruction_order", action="store_true", help="change the order of instructions and query")
+    cfg, _ = parser.parse_known_args()
+
+    main(cfg)

--- a/eval/eval_instructir_bm25_rerank_combine_and_score.py
+++ b/eval/eval_instructir_bm25_rerank_combine_and_score.py
@@ -1,0 +1,86 @@
+'''
+Reformulate scripts from https://github.com/beir-cellar/beir/blob/main/examples/retrieval/evaluation/lexical/evaluate_anserini_bm25.py 
+'''
+import os, json
+import tqdm
+import logging
+import requests
+import argparse 
+from beir.datasets.data_loader import GenericDataLoader
+import os 
+import pickle 
+from beir import util, LoggingHandler
+from collections import defaultdict
+
+from robust_eval import CustomEvaluateRetrieval
+from src.rerankers import MODEL_DICT
+
+def main(args):
+    results = {}
+    for shard_i in range(args.n_shards):
+        model_name = args.model_name.replace("/", "-")
+        with open(f"model_pred/{args.rerank_model}_{model_name}/{shard_i}_{args.n_shards}.pickle", "rb") as f:
+            loaded_results = pickle.load(f)
+            results.update(loaded_results)
+
+    corpus, queries, qrels = GenericDataLoader( 
+        data_folder=args.data_path,
+        corpus_file=args.corpus_file ,
+        qrels_file= os.path.join(args.data_path, args.qrels_folder,args.split + '.tsv'),
+        query_file=args.query_file,
+        ).load_custom()
+    
+    retriever = CustomEvaluateRetrieval()
+
+    #### Retrieve RM3 expanded pyserini results (format of results is identical to qrels)
+    # results = json.loads(requests.post(docker_beir_pyserini + "/lexical/rm3/batch_search/", json=payload).text)["results"]
+
+    ### Check if query_id is in results i.e. remove it from docs incase if it appears ####
+    ### Quite Important for ArguAna and Quora ####
+    for query_id in results:
+        if query_id in results[query_id]:
+            results[query_id].pop(query_id, None)
+
+    logging.info("Retriever evaluation for k in: {}".format(retriever.k_values))
+    # metrics = retriever.evaluate(qrels, results, retriever.k_values)
+    # metrics = retriever.robustness_evaluate(queries, qrels, results, retriever.k_values,type='instruction')
+    metrics = retriever.robustness_evaluate(queries, qrels, results, retriever.k_values,type='query')
+    print(metrics)
+    breakpoint()
+    #### Save
+    # data_path = args.data_path.split('/')[-2]
+    # corpus_file = args.corpus_file.split('.')[0]
+    # split_flag = args.split
+    # query_version = args.query_file.split('.')[0].replace('/','_')
+    # save_path = f'model_pred/{data_path}/{corpus_file}/{split_flag}/{query_version}/'
+
+    # os.makedirs(save_path, exist_ok=True)
+    # save_path += 'bm25.pickle'
+    # with open(save_path,'wb') as f:
+    #     pickle.dump(results,f)
+        
+if __name__=="__main__":    
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--data_path", type=str, default='../data_creation/datasets/msmarco/processed_version/sample_100',
+                        help="Directory to save and load beir datasets")
+    parser.add_argument("--split", type=str,default='test',
+                        help="split for qrels")    
+    parser.add_argument("--corpus_file", type=str, default='corpus.jsonl',
+                        help="corpus file name")
+    parser.add_argument("--query_file", type=str, default='queries.jsonl',
+                        help="query file name")
+    parser.add_argument("--qrels_folder", type=str, default='qrels',
+                        help="qrels folder name")
+    parser.add_argument("--model_name", type=str, default='jhu-clsp/FollowIR-7B')
+    parser.add_argument("--rerank_n", type=int, default=100)
+    parser.add_argument("--batch_size", type=int, default=64)
+    parser.add_argument("--n_shards", type=int, default=1)
+    parser.add_argument("--rerank_model", type=str, default='bm25')
+    parser.add_argument("--change_instruction_order", action="store_true", help="change the order of instructions and query")
+    cfg, _ = parser.parse_known_args()
+    print(cfg)
+
+    main(cfg)
+
+

--- a/eval/eval_rerank.sh
+++ b/eval/eval_rerank.sh
@@ -2,7 +2,7 @@
 
 SPLIT='test'
 CORPUS='corpus.jsonl'
-DATA='/brtx/606-nvme2/oweller2/FollowIR/InstructIR/INSTRUCTIR'
+DATA='INSTRUCTIR'
 
 echo "SPLIT = $SPLIT"
 echo "CORPUS = $CORPUS"
@@ -15,7 +15,12 @@ echo "DATA = $DATA"
     --data_path $DATA \
     --corpus_file $CORPUS \
     --split $SPLIT \
-    --model_name $1
+    --model_name $1 \
+    --n_shards $2 \
+    --shard_id $3 \
+    --rerank_model $4 
+
+
 
 ########################################################
 ###### - version : Analysis - Order Sensitivity

--- a/eval/eval_rerank.sh
+++ b/eval/eval_rerank.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+SPLIT='test'
+CORPUS='corpus.jsonl'
+DATA='/brtx/606-nvme2/oweller2/FollowIR/InstructIR/INSTRUCTIR'
+
+echo "SPLIT = $SPLIT"
+echo "CORPUS = $CORPUS"
+echo "DATA = $DATA"
+
+########################################################
+###### - version : Normal inference mode
+########################################################
+/home/oweller2/anaconda3/envs/kaist-instructir/bin/python -u eval_instructir_bm25_rerank.py \
+    --data_path $DATA \
+    --corpus_file $CORPUS \
+    --split $SPLIT \
+    --model_name $1
+
+########################################################
+###### - version : Analysis - Order Sensitivity
+########################################################
+# python eval_instructir_bm25.py \
+#     --data_path $DATA \
+#     --corpus_file $CORPUS \
+#     --split $SPLIT \
+#     --query_file  'analysis_order_sensitivity/new_queries.jsonl' \
+#     --qrels_folder 'qrels'
+
+########################################################
+###### - version : Analysis - Prompt Sensitivity
+########################################################
+# python eval_instructir_bm25.py \
+#     --data_path $DATA \
+#     --corpus_file $CORPUS \
+#     --split $SPLIT \
+#     --query_file  'analysis_prompt_sensitivity/og_queries.jsonl' \
+#     --qrels_folder 'analysis_prompt_sensitivity/qrels'
+
+# SPLIT='5_test'
+# python eval_instructir_bm25.py \
+#     --data_path $DATA \
+#     --corpus_file $CORPUS \
+#     --split $SPLIT \
+#     --query_file  'analysis_prompt_sensitivity/5new_queries.jsonl' \
+#     --qrels_folder 'analysis_prompt_sensitivity/qrels'

--- a/eval/src/rerankers.py
+++ b/eval/src/rerankers.py
@@ -1,0 +1,452 @@
+import torch
+import torch.nn.functional as F
+import numpy as np
+import tqdm
+import pandas as pd
+from math import ceil, exp
+from typing import List
+from tqdm.auto import tqdm
+from transformers import (
+    AutoConfig,
+    AutoTokenizer,
+    AutoModelForSequenceClassification,
+    AutoModelForSeq2SeqLM,
+    T5ForConditionalGeneration,
+    AutoModelForCausalLM,
+)
+
+# Based on https://github.com/castorini/pygaggle/blob/f54ae53d6183c1b66444fa5a0542301e0d1090f5/pygaggle/rerank/base.py#L63
+prediction_tokens = {
+    "castorini/monot5-small-msmarco-10k": ["▁false", "▁true"],
+    "castorini/monot5-small-msmarco-100k": ["▁false", "▁true"],
+    "castorini/monot5-base-msmarco": ["▁false", "▁true"],
+    "castorini/monot5-base-msmarco-10k": ["▁false", "▁true"],
+    "castorini/monot5-large-msmarco": ["▁false", "▁true"],
+    "castorini/monot5-large-msmarco-10k": ["▁false", "▁true"],
+    "castorini/monot5-base-med-msmarco": ["▁false", "▁true"],
+    "castorini/monot5-3b-med-msmarco": ["▁false", "▁true"],
+    "castorini/monot5-3b-msmarco-10k": ["▁false", "▁true"],
+    "castorini/monot5-3b-msmarco": ["▁false", "▁true"],
+    "unicamp-dl/mt5-base-en-msmarco": ["▁no", "▁yes"],
+    "unicamp-dl/mt5-base-mmarco-v2": ["▁no", "▁yes"],
+    "unicamp-dl/mt5-base-mmarco-v1": ["▁no", "▁yes"],
+}
+
+
+
+def chunks(lst, n):
+    for i in range(0, len(lst), n):
+        yield lst[i : i + n]
+
+
+
+
+class Reranker:
+    def __init__(
+        self,
+        model_name_or_path: str,
+        batch_size: int = 32,
+        fp_options: bool = None,
+        silent: bool = False,
+    ):
+        self.model_name_or_path = model_name_or_path
+        self.batch_size = batch_size
+        self.fp_options = fp_options if fp_options is not None else torch.float32
+        if self.fp_options == "auto":
+            self.fp_options = torch.float32
+        elif self.fp_options == "float16":
+            self.fp_options = torch.float16
+        elif self.fp_options == "float32":
+            self.fp_options = torch.float32
+        elif self.fp_options == "bfloat16":
+            self.fp_options = torch.bfloat16
+        print(f"Using fp_options of {self.fp_options}")
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.silent = silent
+        self.first_print = True
+
+    def rerank(self, query, passages, **kwargs) -> list:
+        pass
+
+
+
+class MonoT5Reranker(Reranker):
+    name: str = "MonoT5"
+    prompt_template: str = "Query: {query} Document: {text} Relevant:"
+
+    def __init__(
+        self,
+        model_name_or_path="castorini/monot5-base-msmarco-10k",
+        **kwargs,
+    ):
+        super().__init__(model_name_or_path, **kwargs)
+        if not self.device:
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        model_args = {}
+        if self.fp_options:
+            model_args["torch_dtype"] = self.fp_options
+        self.model = AutoModelForSeq2SeqLM.from_pretrained(
+            model_name_or_path, **model_args
+        )
+        print(f"Using model {model_name_or_path}")
+        
+        if 'torch_compile' in kwargs and kwargs['torch_compile']:
+            self.torch_compile = kwargs["torch_compile"]
+            self.model = torch.compile(self.model)
+        else:
+            self.torch_compile = False
+
+        self.model.to(self.device)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
+        self.token_false_id, self.token_true_id = self.get_prediction_tokens(
+            model_name_or_path,
+            self.tokenizer,
+            kwargs['token_false'] if 'token_false' in kwargs else None,
+            kwargs['token_true'] if 'token_true' in kwargs else None,
+        )
+        print(f"Using max_length of {self.tokenizer.model_max_length}")
+        print(f"Using token_false_id of {self.token_false_id}")
+        print(f"Using token_true_id of {self.token_true_id}")
+        self.max_length = self.tokenizer.model_max_length
+        print(f"Using max_length of {self.max_length}")
+
+
+        self.model.eval()
+
+
+    def get_prediction_tokens(self, model_name_or_path, tokenizer, token_false=None, token_true=None):
+        if not (token_false and token_true):
+            if model_name_or_path in prediction_tokens:
+                token_false, token_true = prediction_tokens[model_name_or_path]
+                token_false_id = tokenizer.get_vocab()[token_false]
+                token_true_id  = tokenizer.get_vocab()[token_true]
+                return token_false_id, token_true_id
+            else:
+                # raise Exception(f"We don't know the indexes for the non-relevant/relevant tokens for\
+                #         the checkpoint {model_name_or_path} and you did not provide any.")
+                return self.get_prediction_tokens('castorini/monot5-base-msmarco', self.tokenizer)
+        else:
+            token_false_id = tokenizer.get_vocab()[token_false]
+            token_true_id  = tokenizer.get_vocab()[token_true]
+            return token_false_id, token_true_id
+
+
+    @torch.inference_mode()
+    def rerank(self, queries, passages, **kwargs):
+        assert "instructions" in kwargs
+        instructions = kwargs["instructions"]
+        if instructions is not None and instructions[0] is not None:
+            # print(f"Adding instructions to monot5 queries")
+            queries = [f"{q} {i}".strip() for i, q in zip(instructions, queries)]
+
+        prompts = [
+            self.prompt_template.format(query=query, text=text)
+            for (query, text) in zip(queries, passages)
+        ]
+        if self.first_print:
+            print(f"Using {prompts[0]}")
+            self.first_print = False
+
+        tokens = self.tokenizer(
+            prompts,
+            padding=True,
+            truncation=True,
+            return_tensors="pt",
+            max_length=self.max_length,
+            pad_to_multiple_of=(8 if self.torch_compile else None),
+        ).to(self.device)
+        output = self.model.generate(
+            **tokens,
+            max_new_tokens=1,
+            return_dict_in_generate=True,
+            output_scores=True,
+        )
+        batch_scores = output.scores[0]
+        batch_scores = batch_scores[:, [self.token_false_id, self.token_true_id]]
+        batch_scores = torch.nn.functional.log_softmax(batch_scores, dim=1)
+        return batch_scores[:, 1].exp().tolist()
+
+
+class LlamaReranker(Reranker):
+    name: str = "LLAMA-Based"
+
+    def __init__(
+        self, model_name_or_path: str, is_classification: bool = False, **kwargs
+    ):
+        if "torch_compile" in kwargs:
+            del kwargs["torch_compile"]
+        super().__init__(model_name_or_path, **kwargs)
+
+        if "chat" in model_name_or_path:
+            self.template = LLAMA_CHAT_TEMPLATE = """<s>[INST] <<SYS>>
+You are an expert at finding information. Determine if the following document is relevant to the query (true/false).
+<</SYS>>Query: {query}
+Document: {text}
+Relevant: [/INST]"""
+        else:
+            self.template = """Determine if the following document is relevant to the query (true/false).
+
+Query: {query}
+Document: {text}
+Relevant: """
+
+
+        self.query_instruct_template = "{query} {instruction}"
+        print(f"Using query_instruct_template of {self.query_instruct_template}")
+        self.is_classification = is_classification
+
+        model_args = {}
+        if self.fp_options:
+            model_args["torch_dtype"] = self.fp_options
+
+        print(self.template)
+        print(model_name_or_path)
+        if not self.device:
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        self.model = AutoModelForCausalLM.from_pretrained(
+            model_name_or_path, **model_args
+        )
+        self.model.to(self.device)
+
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model_name_or_path, padding_side="left"
+        )
+        self.tokenizer.pad_token = self.tokenizer.eos_token
+        self.tokenizer.padding_side = "left"
+
+        self.token_false_id = self.tokenizer.get_vocab()["false"]
+        self.token_true_id = self.tokenizer.get_vocab()["true"]
+        self.max_length = min(2048, self.tokenizer.model_max_length)
+        print(f"Using max_length of {self.max_length}")
+        self.gpu_count = torch.cuda.device_count()
+        if self.gpu_count > 1:
+            print(f'Using {self.gpu_count} GPUs')
+            self.model = torch.nn.DataParallel(self.model)
+        self.model.eval()
+
+
+    @torch.inference_mode()
+    def rerank(self, queries, passages, **kwargs):
+        assert "instructions" in kwargs
+        instructions = kwargs["instructions"]
+        if instructions is not None and instructions[0] is not None:
+            # print(f"Adding instructions to LLAMA queries")
+            queries = [self.query_instruct_template.format(instruction=i, query=q).strip() for i, q in zip(instructions, queries)]
+
+        prompts = [
+            self.template.format(query=query, text=text) for (query, text) in zip(queries, passages)
+        ]
+        assert "{query}" not in prompts[0], "Query not replaced"
+        assert "{text}" not in prompts[0], "Text not replaced"
+        assert "{instruction}" not in prompts[0], "Instruction not replaced"
+
+        if self.first_print:
+            print(f"Using {prompts[0]}")
+            self.first_print = False
+
+
+        tokens = self.tokenizer(
+            prompts,
+            padding=True,
+            truncation=True,
+            return_tensors="pt",
+            max_length=self.max_length,
+            pad_to_multiple_of=None,
+        ).to(self.device)
+        if "token_type_ids" in tokens:
+            del tokens["token_type_ids"]
+        if not self.is_classification:
+            batch_scores = self.model(**tokens).logits[:, -1, :]
+            true_vector = batch_scores[:, self.token_true_id]
+            false_vector = batch_scores[:, self.token_false_id]
+            batch_scores = torch.stack([false_vector, true_vector], dim=1)
+            batch_scores = torch.nn.functional.log_softmax(batch_scores, dim=1)
+            scores = batch_scores[:, 1].exp().tolist()
+        else:
+            batch_scores = self.model(**tokens).logits
+            batch_scores = torch.nn.functional.log_softmax(batch_scores, dim=1)
+            scores = batch_scores[:, 1].exp().tolist()
+
+        return scores
+
+
+class MistralReranker(LlamaReranker):
+    name: str = "Mistral"
+
+    def __init__(self, model_name_or_path: str, **kwargs):
+        # use the base class for everything except template
+        super().__init__(model_name_or_path, **kwargs)
+        self.template = """<s>[INST] You are an expert Google searcher, whose job is to determine if the following document is relevant to the query (true/false).
+Query: {query}
+Document: {text}
+Relevant (either "true" or "false"): [/INST]"""
+        self.max_length = min(2048, self.tokenizer.model_max_length)
+        print(f"Using max_length of {self.max_length}")
+        print(f"Using template of {self.template}")
+
+
+class FollowIRReranker(LlamaReranker):
+    name: str = "FollowIR"
+
+    def __init__(self, model_name_or_path: str, **kwargs):
+        # use the base class for everything except template
+        kwargs["fp_options"] = "bfloat16"
+        super().__init__(model_name_or_path, **kwargs)
+        self.template = """<s> [INST] You are an expert Google searcher, whose job is to determine if the following document is relevant to the query (true/false). Answer using only one word, one of those two choices.
+
+Query: {query}
+Document: {text}
+Relevant (only output one word, either "true" or "false"): [/INST] """
+        self.max_length = min(2048, self.tokenizer.model_max_length)
+        # self.query_instruct_template = "\"{query}\", details: \"{instruction}\""
+        print(f"Using query_instruct_template of {self.query_instruct_template}")
+        print(f"Using template of {self.template}")
+
+
+
+class FLANT5Reranker(MonoT5Reranker):
+    name: str = "FLAN-T5"
+    prompt_template: str = """Is the following passage relevant to the query?
+Query: {query}
+Passage: {text}"""
+
+    def get_prediction_tokens(self, *args, **kwargs):
+        yes_token_id, *_ = self.tokenizer.encode("yes")
+        no_token_id, *_ = self.tokenizer.encode("no")
+        return no_token_id, yes_token_id
+
+
+
+class MonoBERTReranker(Reranker):
+    name: str = "MonoBERT"
+
+    def __init__(
+        self,
+        model_name_or_path="castorini/monobert-large-msmarco",
+        torch_compile=False,
+        **kwargs,
+    ):
+        super().__init__(model_name_or_path, **kwargs)
+        if not self.device:
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        model_args = {}
+        if self.fp_options:
+            model_args["torch_dtype"] = self.fp_options
+        self.model = AutoModelForSequenceClassification.from_pretrained(
+            model_name_or_path,
+            **model_args,
+        )
+        self.model.to(self.device)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
+        self.max_length = self.tokenizer.model_max_length
+        print(f"Using max_length of {self.max_length}")
+
+        self.model.eval()
+
+
+    @torch.inference_mode()
+    def rerank(self, queries, passages, **kwargs):
+        assert "instructions" in kwargs
+        instructions = kwargs["instructions"]
+        if instructions is not None and instructions[0] is not None:
+            # print(f"Adding instructions to MonoBERT queries")
+            queries = [f"{q} {i}".strip() for i, q in zip(instructions, queries)]
+
+
+        if self.first_print:
+            print(f"Using {queries[0]}")
+            self.first_print = False
+
+        tokens = self.tokenizer(
+            queries,
+            passages,
+            padding=True,
+            truncation="only_second",
+            return_tensors="pt",
+            max_length=self.max_length,
+        ).to(self.device)
+        output = self.model(**tokens)[0]
+        batch_scores = torch.nn.functional.log_softmax(output, dim=1)
+        return batch_scores[:, 1].exp().tolist()
+
+
+# class TARTFullReranker(Reranker):
+#     def __init__(self, model_name_or_path: str, **kwargs):
+#         super().__init__(model_name_or_path, **kwargs)
+#         from modeling_enc_t5 import EncT5ForSequenceClassification
+#         from tokenization_enc_t5 import EncT5Tokenizer
+#         assert model_name_or_path in ["facebook/tart-full-flan-t5-xl", "facebook/tart-full-t0-3b"]
+#         self.model = EncT5ForSequenceClassification.from_pretrained(model_name_or_path)
+#         self.tokenizer =  EncT5Tokenizer.from_pretrained(model_name_or_path)
+#         self.max_length = 1024
+#         print(f"Using max_length of {self.max_length}")
+
+#         self.model.eval()
+
+
+#     @torch.inference_mode()
+#     def rerank(self, queries, passages, **kwargs):
+#         assert "instructions" in kwargs
+#         instructions = kwargs["instructions"]
+#         if instructions is not None and instructions[0] is not None:
+#             # combine them with the queries with a [SEP] token
+#             if instructions[0].strip() == "": # empty instruction case, use generic
+#                 queries = [f"{query} [SEP] Retrieve news paper paragraph to answer this question" for query in queries]
+#             else:
+#                 queries = [f"{query} [SEP] {instruction}".strip() for query, instruction in zip(queries, instructions)]
+
+#         assert len(queries) == len(
+#             passages
+#         ), "queries and passages must be the same length"
+#         for query in queries:
+#             assert " [SEP] " in query, "query must contain [SEP]"
+
+#         if torch.cuda.is_available():
+#             self.model.to("cuda")
+#             # print("Loaded model to cuda")
+
+#         if self.first_print:
+#             print(f"Using {queries[0]}")
+#             self.first_print = False
+
+#         self.model.eval()
+
+#         features = self.tokenizer(
+#             queries,
+#             passages,
+#             padding=True,
+#             return_tensors="pt",
+#             truncation="only_second",
+#             max_length=self.max_length,
+#         )
+        
+#         if torch.cuda.is_available():
+#             features = {k: v.to("cuda") for k, v in features.items()}
+#         with torch.no_grad():
+#             scores = self.model(**features).logits
+#             normalized_scores = [
+#                 float(score[1]) for score in F.softmax(scores, dim=1)
+#             ]
+#         return normalized_scores
+
+
+
+
+MODEL_DICT = {
+    # "facebook/tart-full-flan-t5-xl": TARTFullReranker, # requires extra package
+    "castorini/monot5-small-msmarco-10k": MonoT5Reranker,
+    "castorini/monot5-base-msmarco-10k": MonoT5Reranker,
+    "castorini/monot5-large-msmarco-10k": MonoT5Reranker,
+    "castorini/monot5-3b-msmarco-10k": MonoT5Reranker,
+    "google/flan-t5-base": FLANT5Reranker,
+    "google/flan-t5-large": FLANT5Reranker,
+    "google/flan-t5-xl": FLANT5Reranker,
+    "google/flan-t5-xxl": FLANT5Reranker,
+    "castorini/monobert-large-msmarco": MonoBERTReranker,
+    "meta-llama/Llama-2-7b-hf": LlamaReranker,
+    "meta-llama/Llama-2-7b-chat-hf": LlamaReranker,
+    "mistralai/Mistral-7B-Instruct-v0.2": MistralReranker,
+    "custom_mistral": FollowIRReranker,
+    "jhu-clsp/FollowIR-7B": FollowIRReranker,
+}

--- a/eval/src/rerankers.py
+++ b/eval/src/rerankers.py
@@ -232,7 +232,7 @@ Relevant: """
         instructions = kwargs["instructions"]
         if instructions is not None and instructions[0] is not None:
             # print(f"Adding instructions to LLAMA queries")
-            queries = [self.query_instruct_template.format(instruction=i, query=q).strip() for i, q in zip(instructions, queries)]
+            queries = [self.query_instruct_template.format(instruction=i, query=q + "?").strip() for i, q in zip(instructions, queries)]
 
         prompts = [
             self.template.format(query=query, text=text) for (query, text) in zip(queries, passages)
@@ -276,6 +276,7 @@ class MistralReranker(LlamaReranker):
 
     def __init__(self, model_name_or_path: str, **kwargs):
         # use the base class for everything except template
+        kwargs["fp_options"] = "float16"
         super().__init__(model_name_or_path, **kwargs)
         self.template = """<s>[INST] You are an expert Google searcher, whose job is to determine if the following document is relevant to the query (true/false).
 Query: {query}
@@ -291,7 +292,7 @@ class FollowIRReranker(LlamaReranker):
 
     def __init__(self, model_name_or_path: str, **kwargs):
         # use the base class for everything except template
-        kwargs["fp_options"] = "bfloat16"
+        kwargs["fp_options"] = "float16"
         super().__init__(model_name_or_path, **kwargs)
         self.template = """<s> [INST] You are an expert Google searcher, whose job is to determine if the following document is relevant to the query (true/false). Answer using only one word, one of those two choices.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ InstructorEmbedding
 peft
 beir
 sentence-transformers==2.2.2
+protobuf


### PR DESCRIPTION
Hi again and thanks for the great work on InstructIR!

This is an optional PR and you can just decline it.

I just wanted to post it in case you or someone else was interested in using rerankers on InstructIR.  It is fairly compute intensive, about 12 hours on 4 A100 80GB GPUs to evaluate a 7B Mistral model on the top 100.

The results I got were:
| Model                           | Robustness@10 | nCDG@10 |
|---------------------------------|---------------|---------|
| BM25                            | 0.277         | 0.761   |
| BM25 + Mistral 7B Instruct v0.2 | 0.353         | 0.631   |
| BM25 + FollowIR-7B              | 0.715         | 0.813   |

I have scripts here for:

- Saving the BM25 predictions so that they can be used for reranking (also included the gzip'd predictions for others)
- A script to rerank the top N BM25 predictions
- Code for the reranker models themselves
- Code that aggregates multiple shards of the predictions into a final one for scoring (since I parallelized the reranking to make it faster)

If you're interested in actually merging this in, I'm happy to make changes to align with your repository. Otherwise feel free to just ignore it also :) 